### PR TITLE
Process multilanguage tags in relevant table cells

### DIFF
--- a/classes/output/audit_table.php
+++ b/classes/output/audit_table.php
@@ -86,7 +86,7 @@ class audit_table extends table_sql implements renderable {
      * @return string html used to display the column field.
      */
     public function col_category($activity) {
-        return $this->format_text($activity->category);
+        return $this->format_text(format_string($activity->category));
     }
 
     /**
@@ -99,9 +99,9 @@ class audit_table extends table_sql implements renderable {
      */
     public function col_coursefullname($activity) {
         if ($this->is_downloading()) {
-            return $this->format_text($activity->coursefullname);
+            return $this->format_text(format_string($activity->coursefullname));
         }
-        return $this->format_text(html_writer::link(new moodle_url($activity->courseurl), $activity->coursefullname), FORMAT_HTML);
+        return $this->format_text(html_writer::link(new moodle_url($activity->courseurl), format_string($activity->coursefullname)), FORMAT_HTML);
     }
 
     /**


### PR DESCRIPTION
Hi Dan,

thank you for this helpful report plugin.
I would like to propose to process multilanguage tags in category, course and activity names to prevent cluttering of the table due to non-filtered names.

Cheers,
Alex