### PR TITLE
Fix variable interpolation

### DIFF
--- a/classes/audit_manager.php
+++ b/classes/audit_manager.php
@@ -164,7 +164,7 @@ class audit_manager {
 
         if (!$legacy) {
             $sql .= "JOIN {course_modules} cm on cm.id = cx.instanceid "
-              . "JOIN {$module} s on s.id = cm.instance "
+              . "JOIN {{$module}} s on s.id = cm.instance "
               . "JOIN {course} c on c.id = s.course ";
         } else {
             $sql .= "JOIN {course} c on c.id = cx.instanceid ";


### PR DESCRIPTION
{$var} will embed the variable but not preserve the {} for Moodle purposes; it's used in cases to encapsulate the variable where it would otherwise clash with content, e.g. "{$class}suffix"